### PR TITLE
Cloud Run module: some revision attributes moved to service_config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ uv add <dependency>
 
 ```shell
 # Generate tfdoc for cloud-run-single/0-projects
-./tools/tfdoc.py modules/cloud-run-single/0-projects
+./tools/tfdoc.py cloud-run-single/0-projects
 ```
 
 ### Run tests
@@ -65,10 +65,13 @@ uv run pytest tests/cloud_run_single/0-projects
 
 ### Generate the inventory for a factory module
 
+Run the command below and remove your user name from the output file in path `.values.google_service_account_iam_member.me_sa_token_creator[0].member`:
+
 ```shell
 # Generate the inventory for cloud-run-single/0-projects
-python tools/plan_summary.py cloud-run-single/0-projects \
-  tests/cloud_run_single/0_projects/simple.tfvars
+uv run tools/plan_summary.py cloud-run-single/0-projects \
+  tests/cloud_run_single/0_projects/simple.tfvars \
+  > tests/cloud_run_single/0_projects/simple.yaml
 ```
 
 ## Add a new factory

--- a/cloud-run-rag-search/1-apps/frontend.tf
+++ b/cloud-run-rag-search/1-apps/frontend.tf
@@ -26,8 +26,6 @@ module "cloud_run_frontend" {
     "roles/run.invoker" = var.cloud_run_configs.frontend.service_invokers
   }
   revision = {
-    gen2_execution_environment = true
-    max_instance_count         = var.cloud_run_configs.frontend.max_instance_count
     vpc_access = {
       egress  = var.cloud_run_configs.frontend.vpc_access_egress
       network = local.vpc_id
@@ -38,5 +36,6 @@ module "cloud_run_frontend" {
   service_config = {
     gen2_execution_environment = true
     ingress                    = var.cloud_run_configs.frontend.ingress
+    max_instance_count         = var.cloud_run_configs.frontend.max_instance_count
   }
 }

--- a/cloud-run-rag-search/1-apps/ingestion.tf
+++ b/cloud-run-rag-search/1-apps/ingestion.tf
@@ -29,18 +29,17 @@ module "cloud_run_ingestion" {
     )
   }
   revision = {
-    gen2_execution_environment = true
-    max_instance_count         = var.cloud_run_configs.ingestion.max_instance_count
-    tags                       = var.cloud_run_configs.ingestion.vpc_access_tags
     vpc_access = {
       egress  = var.cloud_run_configs.ingestion.vpc_access_egress
       network = local.vpc_id
       subnet  = local.subnet_id
+      tags    = var.cloud_run_configs.ingestion.vpc_access_tags
     }
   }
   service_config = {
     gen2_execution_environment = true
     ingress                    = var.cloud_run_configs.ingestion.ingress
+    max_instance_count         = var.cloud_run_configs.ingestion.max_instance_count
   }
 }
 

--- a/cloud-run-rag/1-apps/frontend.tf
+++ b/cloud-run-rag/1-apps/frontend.tf
@@ -44,8 +44,6 @@ module "cloud_run_frontend" {
     "roles/run.invoker" = var.cloud_run_configs.frontend.service_invokers
   }
   revision = {
-    gen2_execution_environment = true
-    max_instance_count         = var.cloud_run_configs.frontend.max_instance_count
     vpc_access = {
       egress  = var.cloud_run_configs.frontend.vpc_access_egress
       network = local.vpc_id
@@ -56,5 +54,6 @@ module "cloud_run_frontend" {
   service_config = {
     gen2_execution_environment = true
     ingress                    = var.cloud_run_configs.frontend.ingress
+    max_instance_count         = var.cloud_run_configs.frontend.max_instance_count
   }
 }

--- a/cloud-run-rag/1-apps/ingestion.tf
+++ b/cloud-run-rag/1-apps/ingestion.tf
@@ -48,18 +48,17 @@ module "cloud_run_ingestion" {
     )
   }
   revision = {
-    gen2_execution_environment = true
-    max_instance_count         = var.cloud_run_configs.ingestion.max_instance_count
-    tags                       = var.cloud_run_configs.ingestion.vpc_access_tags
     vpc_access = {
       egress  = var.cloud_run_configs.ingestion.vpc_access_egress
       network = local.vpc_id
       subnet  = local.subnet_id
+      tags    = var.cloud_run_configs.ingestion.vpc_access_tags
     }
   }
   service_config = {
     gen2_execution_environment = true
     ingress                    = var.cloud_run_configs.ingestion.ingress
+    max_instance_count         = var.cloud_run_configs.ingestion.max_instance_count
   }
 }
 

--- a/cloud-run-single/1-apps/main.tf
+++ b/cloud-run-single/1-apps/main.tf
@@ -26,8 +26,6 @@ module "cloud_run" {
     "roles/run.invoker" = var.cloud_run_configs.service_invokers
   }
   revision = {
-    gen2_execution_environment = true
-    max_instance_count         = var.cloud_run_configs.max_instance_count
     vpc_access = {
       egress  = var.cloud_run_configs.vpc_access_egress
       network = local.vpc_id
@@ -38,5 +36,6 @@ module "cloud_run" {
   service_config = {
     gen2_execution_environment = true
     ingress                    = var.cloud_run_configs.ingress
+    max_instance_count         = var.cloud_run_configs.max_instance_count
   }
 }


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/tree/master/modules/cloud-run-v2 - some "revision" attributes were moved to "service_config". The validation was not working for them, so this fix is going to be merged soon on the Fabric side as well: https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/tree/fix_cloudrun_validation/modules/cloud-run-v2